### PR TITLE
Fix filter of getCookies

### DIFF
--- a/packages/queue-run/src/http/handler.ts
+++ b/packages/queue-run/src/http/handler.ts
@@ -173,7 +173,7 @@ function getCookies(request: Request): { [key: string]: string } {
     .split(";")
     .map((cookie) => cookie.trim())
     .map((cookie) => cookie.match(/^([^=]+?)=(.*)$/)?.slice(1)!)
-    .filter(([name]) => name) as [string, string][];
+    .filter(entry => entry && entry.slice(-1)) as [string, string][];
 
   return cookies.reduce(
     (cookies, [key, value]) => ({ ...cookies, [key]: value }),


### PR DESCRIPTION
When receiving:
next-auth.session-token=eyJhbGciOiJIUzUxMiJ9.eyJuYW1lIjoiTWVyY2FkbyBBZ29yYSBBZG1pbiIsImVtYWlsIjoiYWRtaW5AbWVyY2Fkb2Fnb3JhLmNvbS5iciIsInBpY3R1cmUiOm51bGwsInN1YiI6Ijc3Yzg5MDY3LTNjMGEtNDlhNS1hMzgzLTJkYzhmMjFhZjhhMyIsImlhdCI6MTYzMDY2MjA0MywiZXhwIjoxNjMzMjU0MDQzfQ.MyOb9SqM4hbJunVpWBL22usEX8OUrhlc71jZXneZwGI7ggBIjXfbLlzGN_t1c_8jkevWPWuqubmbOVbUMPpLiA;
Path=/; Expires=Sun, 03 Oct 2021 09:40:43 GMT; HttpOnly; SameSite=Lax

It was getting undefined:

```
[
  [
    'next-auth.session-token',
    'eyJhbGciOiJIUzUxMiJ9.eyJuYW1lIjoiTWVyY2FkbyBBZ29yYSBBZG1pbiIsImVtYWlsIjoiYWRtaW5AbWVyY2Fkb2Fnb3JhLmNvbS5iciIsInBpY3R1cmUiOm51bGwsInN1YiI6Ijc3Yzg5MDY3LTNjMGEtNDlhNS1hMzgzLTJkYzhmMjFhZjhhMyIsImlhdCI6MTYzMDY2MjA0MywiZXhwIjoxNjMzMjU0MDQzfQ.MyOb9SqM4hbJunVpWBL22usEX8OUrhlc71jZXneZwGI7ggBIjXfbLlzGN_t1c_8jkevWPWuqubmbOVbUMPpLiA'
  ],
  [ 'Path', '/' ],
  [ 'Expires', 'Sun, 03 Oct 2021 09:40:43 GMT' ],
  undefined,
  [ 'SameSite', 'Lax' ]
]
```